### PR TITLE
Ch5: Representing Code

### DIFF
--- a/src/loxide/ast.rs
+++ b/src/loxide/ast.rs
@@ -1,0 +1,25 @@
+use super::token::Token;
+
+pub enum Expr {
+    Binary {
+        left: Box<Expr>,
+        operator: Token,
+        right: Box<Expr>,
+    },
+    Grouping {
+        expr: Box<Expr>,
+    },
+    Literal {
+        value: Token,
+    },
+    Unary {
+        operator: Token,
+        right: Box<Expr>,
+    },
+}
+
+pub trait Visitor {
+    type ExprReturn;
+
+    fn visit_expr(&self, expr: &Expr) -> Self::ExprReturn;
+}

--- a/src/loxide/ast_printer.rs
+++ b/src/loxide/ast_printer.rs
@@ -1,0 +1,43 @@
+use super::{
+    ast::{Expr, Visitor},
+    token_type::TokenType,
+};
+
+pub struct AstPrinter;
+
+impl AstPrinter {
+    pub fn visit_expr(&self, expr: &Expr) -> String {
+        Visitor::visit_expr(self, expr)
+    }
+}
+
+impl Visitor for AstPrinter {
+    type ExprReturn = String;
+
+    fn visit_expr(&self, expr: &Expr) -> Self::ExprReturn {
+        match expr {
+            Expr::Binary {
+                left,
+                operator,
+                right,
+            } => format!(
+                "({} {} {})",
+                operator.get_lexeme(),
+                self.visit_expr(left),
+                self.visit_expr(right),
+            ),
+            Expr::Grouping { expr } => format!("(group {})", self.visit_expr(expr)),
+            Expr::Literal { value } => match value.get_token_type() {
+                TokenType::Nil => String::from("nil"),
+                TokenType::True => String::from("true"),
+                TokenType::False => String::from("false"),
+                TokenType::Number(v) => v.to_string(),
+                TokenType::String(v) => v,
+                _ => panic!("Invalid token type"),
+            },
+            Expr::Unary { operator, right } => {
+                format!("({} {})", operator.get_lexeme(), self.visit_expr(right))
+            }
+        }
+    }
+}

--- a/src/loxide/mod.rs
+++ b/src/loxide/mod.rs
@@ -4,9 +4,11 @@ use thiserror::Error;
 
 use self::scanner::Scanner;
 
+pub mod ast;
+pub mod ast_printer;
 mod scanner;
-mod token;
-mod token_type;
+pub mod token;
+pub mod token_type;
 
 #[derive(Debug, Error)]
 pub enum Error {

--- a/src/loxide/token.rs
+++ b/src/loxide/token.rs
@@ -17,6 +17,14 @@ impl Token {
             line,
         }
     }
+
+    pub fn get_lexeme(&self) -> &str {
+        &self.lexeme
+    }
+
+    pub fn get_token_type(&self) -> TokenType {
+        self.token_type.to_owned()
+    }
 }
 
 impl fmt::Display for Token {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,29 @@
+use loxide::ast::Expr;
+use loxide::ast_printer::AstPrinter;
+use loxide::token::Token;
+use loxide::token_type::TokenType;
 use loxide::{Error, Loxide};
 
 mod loxide;
 
 fn main() {
+    // Print test AST
+    let expression = Expr::Binary {
+        left: Box::new(Expr::Unary {
+            operator: Token::new(TokenType::Minus, String::from("-"), 1),
+            right: Box::new(Expr::Literal {
+                value: Token::new(TokenType::Number(123.0), String::from("123"), 1),
+            }),
+        }),
+        operator: Token::new(TokenType::Star, String::from("*"), 1),
+        right: Box::new(Expr::Grouping {
+            expr: Box::new(Expr::Literal {
+                value: Token::new(TokenType::Number(45.67), String::from("45.67"), 1),
+            }),
+        }),
+    };
+    println!("{}", AstPrinter.visit_expr(&expression));
+
     let args = std::env::args().collect::<Vec<String>>();
     let mut loxide = Loxide::new();
     match args.len() {


### PR DESCRIPTION
- Adds a basic `Expr` enum to represent initial simple expressions
- Adds a `Visitor` trait to recursively handle expressions
- Adds an `AstPrinter` struct to print a generated syntax tree (for validating `Expr` and `Visitor`)